### PR TITLE
Bump dependencies to last versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,11 +3,10 @@ description: A fresh Flutter project created using Purple Starter.
 
 publish_to: 'none'
 
-version: 1.0.0+1
+version: 1.0.0+2
 
 environment:
-  sdk: '>=2.16.2'
-  flutter: '>=2.10.5'
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -30,21 +29,21 @@ dependencies:
   sum: ^0.2.0
 
   # BLoC
-  stream_bloc: ^0.4.0
+  stream_bloc: ^0.5.1
 
   # Flutter integrations
   flutter_bloc: ^8.0.1
   provider: ^6.0.2
 
   # Code generation
-  freezed_annotation: ^1.1.0
+  freezed_annotation: ^2.1.0
   json_annotation: ^4.4.0
   select_annotation: ^0.2.0
 
   # Internationalization
   intl: ^0.17.0
   flutter_localizations:
-    sdk: flutter 
+    sdk: flutter
 
   # Logging
   l: ^3.1.0
@@ -61,24 +60,24 @@ dependencies:
   retrofit: ^3.0.1
 
   # Navigation
-  auto_route: ^3.2.4
+  auto_route: ^5.0.1
 
 dev_dependencies:
   # Analyzer extensions
   dart_code_metrics: ^4.13.0
-  purple_metrics_lints: ^0.2.0
+  purple_metrics_lints: ^0.3.0
 
   # Utils
-  flutter_launcher_icons: ^0.9.2
+  flutter_launcher_icons: ^0.10.0
   flutter_native_splash: ^2.0.5
 
   # Code generation
   build_runner: ^2.1.7
-  auto_route_generator: ^3.2.3
-  select: ^0.2.0
+  auto_route_generator: ^5.0.2
+  select: ^0.3.1
   retrofit_generator: ^4.0.1
   drift_dev: ^1.2.0
-  freezed: ^1.1.0
+  freezed: ^2.1.0+1
   json_serializable: ^6.1.4
   flutter_gen_runner: ^4.1.5
 
@@ -100,7 +99,7 @@ dev_dependencies:
 
 flutter_gen:
   output: lib/src/core/resources
-  
+
 flutter:
   uses-material-design: true
   generate: true


### PR DESCRIPTION
Hi, we should keep our dependencies freshly
Also, this simple solution fix error below:

```
[SEVERE] select:select on lib/src/feature/app/bloc/initialization_bloc.dart:

@selectable can only be used on Class
package:purple_starter/src/feature/app/bloc/initialization_bloc.dart:47:7
   ╷
47 │ mixin _IndexedInitializationStateMixin {
   │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```